### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.eyecreate.qiflora.json
+++ b/org.eyecreate.qiflora.json
@@ -1,7 +1,7 @@
 {
   "id": "org.eyecreate.qiflora",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "qiflora",
   "finish-args": [


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.